### PR TITLE
removed rewrite of /etc/resolv.conf in vault docker Image creation

### DIFF
--- a/assets/playbooks/server-map-playbook.yml
+++ b/assets/playbooks/server-map-playbook.yml
@@ -43,7 +43,10 @@
     - name: Building docker images
       shell:
         chdir: /tmp/servers
-        cmd: /usr/local/bin/docker-or-podman build -t freva-map:latest .
+        cmd: >
+          /usr/local/bin/docker-or-podman build 
+          -t freva-map:latest 
+          --dns 8.8.8.8 .
       become: true
     - name: Creating directory structure
       file:

--- a/assets/playbooks/vault-server-playbook.yml
+++ b/assets/playbooks/vault-server-playbook.yml
@@ -67,7 +67,8 @@
         cmd: >
           /usr/local/bin/docker-or-podman build
           --build-arg=project={{ project_name }}
-          --build-arg=rootpw='{{ root_passwd }}' -t {{ vault_name }}:latest .
+          --build-arg=rootpw='{{ root_passwd }}' -t {{ vault_name }}:latest 
+          --dns 8.8.8.8 .
       become: true
     - name: Starting vault container
       shell: /usr/local/bin/docker-or-podman run -d {{docker_cmd}}

--- a/assets/servers/Dockerfile
+++ b/assets/servers/Dockerfile
@@ -7,7 +7,7 @@ ENV SERVER_FILE="/var/freva/servers.toml"
 COPY restservice.py /usr/local/bin/restservice
 RUN groupadd -g 9999 python
 RUN useradd -ms /bin/bash -d /var/freva python -u 9999 -g 9999
-RUN python3 -m ensurepip && echo "nameserver 8.8.8.8" >> /etc/resolv.conf &&\
+RUN python3 -m ensurepip &&\
     chmod +x /usr/local/bin/restservice &&\
     pip3 install --no-cache --upgrade pip setuptools toml requests flask flask_restful
 USER python

--- a/assets/vault/Dockerfile
+++ b/assets/vault/Dockerfile
@@ -22,8 +22,7 @@ RUN set -ex &&\
 
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools &&\
-    pip3 install requests flask flask_restful &&\
-    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+    pip3 install requests flask flask_restful
 
 EXPOSE 5002
 VOLUME /vault/file


### PR DESCRIPTION
```yaml
RUN pip3 install --no-cache --upgrade pip setuptools &&\
    pip3 install requests flask flask_restful &&\
    echo "nameserver 8.8.8.8" >> /etc/resolv.conf <----
```
was throwing the following error
```
#0 10.03 /bin/sh: can't create /etc/resolv.conf: Read-only file system
```
and apparently it was due to trying to write on the host's own `/etc/resolv.conf` file

with this line removed I could run the deployment (of the database, that required vault) with no problem.

----

NOTE: [the db-server-playbook.yml](https://github.com/FREVA-CLINT/freva-deployment/blob/main/assets/servers/Dockerfile#L10) also has the same line.
```yaml
RUN python3 -m ensurepip && echo "nameserver 8.8.8.8" >> /etc/resolv.conf &&\
```
