### PR TITLE
Add Makefile for dev purporse

### DIFF
--- a/.github/workflows/ci_job.yml
+++ b/.github/workflows/ci_job.yml
@@ -24,7 +24,7 @@ jobs:
         mkdir .mypy_cache
     -
       name: formating
-      run: isort --profile black -t py311 -l 79 src
+      run: isort -c --profile black -t py311 -l 79 src
     -
       name: type checking
       run: mypy --install-types --non-interactive

--- a/.github/workflows/pypi_job.yml
+++ b/.github/workflows/pypi_job.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Adding the evaluation config file
-        run: wget https://raw.githubusercontent.com/FREVA-CLINT/freva/main/assets/evaluation_system.conf -O assets/share/freva/deployment/config/evaluation_system.conf.tmpl
+        run: python src/freva_deployment/__init__.py
       -
         name: Install flit
         run: python -m pip install flit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: develop install prepare lint docs
+all: develop
+
+develop: prepare
+	python3 -m pip install -e .[test,docs]
+
+install: prepare
+	python3 -m pip install .[test,docs]
+
+prepare:
+	python src/freva_deployment/__init__.py
+
+lint:
+	isort --profile black -t py311 -l 79 src
+	mypy --install-types --non-interactive
+
+docs:
+	make -C docs clean
+	make -C docs html

--- a/README.md
+++ b/README.md
@@ -306,3 +306,38 @@ git config --global user.email your@email.com
 
 # Advanced: Adjusting the playbook
 Playbook templates and be found the in the `playbooks` directory. You can also add new variables to the playbook if they are present in the `config/inventory` file.
+
+# Contributing to freva-deployment
+
+We welcome contributions from the community! Before you start contributing,
+please follow these steps to set up your development environment.
+Make sure you have the following prerequisites installed:
+
+- Python (>=3.x)
+- Git
+- Make
+
+```console
+git clone https://github.com/FREVA-CLINT/freva-deployment.git
+cd freva-deployment.git
+```
+## Development Workflow
+
+We use a Makefile to manage common development tasks. Here are some useful
+commands:
+
+
+1. To install in development mode use:
+```console
+make
+```
+
+2. To reformat and do type checking:
+```console
+make lint
+```
+
+3. Generate the documentation:
+```console
+make docs
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,46 @@ basic deployment setup and servicing Freva will be introduced.
    LegalNotes
    modules
 
+Contributing to freva-deployment
+================================
 
+We welcome contributions from the community! Before you start contributing,
+please follow these steps to set up your development environment.
+Make sure you have the following prerequisites installed:
+
+- Python (>=3.x)
+- Git
+- Make
+
+.. code:: console
+
+    git clone https://github.com/FREVA-CLINT/freva-deployment.git
+    cd freva-deployment.git
+
+Development Workflow
+--------------------
+
+We use a Makefile to manage common development tasks. Here are some useful
+commands:
+
+
+1. To install in development mode use:
+
+.. code:: console
+
+    make
+
+2. To reformat and do type checking:
+
+.. code:: console
+
+    make lint
+
+3. Generate the documentations:
+
+.. code:: console
+
+    make docs
 
 Indices and tables
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ deploy-freva-map = "freva_deployment.cli:server_map"
 freva-service = "freva_deployment.cli:service"
 freva-migrate = "freva_deployment.cli:migrate"
 deploy-freva = "freva_deployment.ui.deployment_tui:tui"
+install_script = "freva_deployment:download_auxiliry_data"
 
 
 [tool.flit.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 description = "Deployment of the Free Evaluation Framework Freva"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [ "appdirs",
              "ansible>=2.10",
              "npyscreen",
@@ -45,8 +45,8 @@ test = ["mypy", "black", "isort", "types-toml", "types-PyMySQL"]
 
 [project.urls]
 Documentation = "https://freva-deployment.readthedocs.io/en/latest/"
-Issues = "https://github.com/FREVA-CLINT/freva/issues"
-Source = "https://github.com/FREVA-CLINT/freva"
+Issues = "https://github.com/FREVA-CLINT/freva-deployment/issues"
+Source = "https://github.com/FREVA-CLINT/freva-deployment"
 Home = "https://freva-deployment.readthedocs.io/en/latest"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ deploy-freva-map = "freva_deployment.cli:server_map"
 freva-service = "freva_deployment.cli:service"
 freva-migrate = "freva_deployment.cli:migrate"
 deploy-freva = "freva_deployment.ui.deployment_tui:tui"
-install_script = "freva_deployment:download_auxiliry_data"
 
 
 [tool.flit.sdist]

--- a/src/freva_deployment/__init__.py
+++ b/src/freva_deployment/__init__.py
@@ -1,3 +1,5 @@
+from urllib.request import urlretrieve
+
 __version__ = "2309.0.1"
 AVAILABLE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 AVAILABLE_CONDA_ARCHS = [
@@ -7,3 +9,34 @@ AVAILABLE_CONDA_ARCHS = [
     "Linux-s390x",
     "MacOSX-x86_64",
 ]
+
+
+def download_auxiliry_data():
+    """Download any data that needs to be downloaded."""
+
+    def reporthook(count, block_size, total_size):
+        if count == 0:
+            return
+        frac = count * block_size / total_size
+        percent = int(100 * frac)
+        bar = "#" * int(frac * 40)
+        msg = "Downloading: [{0:<{1}}] | {2}% Completed".format(
+            bar, 40, round(percent, 2)
+        )
+        print(msg, end="\r", flush=True)
+        if frac >= 1:
+            print()
+
+    urls = {
+        "https://raw.githubusercontent.com/FREVA-CLINT/"
+        "freva/main/assets/evaluation_system.conf": (
+            "assets/share/freva/deployment/config/evaluation_system.conf.tmpl"
+        )
+    }
+
+    for source, target in urls.items():
+        urlretrieve(source, filename=target, reporthook=reporthook)
+
+
+if __name__ == "__main__":
+    download_auxiliry_data()


### PR DESCRIPTION
This fixes #55. I couldn't find a nice solution that downloads the data with `pip install -e .` without too much hassle. So I figured, as I said yesterday that I would just add a Makefile and explain it in the README/docu. 

I also added Makefile instructions for building docs and linting.


@Karinon 