### PR TITLE
fix: fix typos in documentation and also change incorrect naming in functions and playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 The code in this repository is used to deploy freva in different computing
 environments. The general strategy is to split the deployment into
 4 different steps, these are :
+
 - Deploy MariaDB service via docker
 - Deploy a Hashicorp Vault service for storing and retrieving passwords
   and other sensitive data via docker
   (this step get automatically activated once the MariaDB service is set)
 - Deploy Apache Solr service via docker
 - Deploy command line interface backend ([evaluation_system](https://github.com/FREVA-CLINT/freva))
-- Deploy web front end ([freva_web](https://gitlab.dkrz.de/freva/freva_web))
+- Deploy web front end ([freva_web](https://github.com/FREVA-CLINT/freva-web))
 
 
 > **_Note:_** A vault server is auto deployed once the mariadb server is deployed.
@@ -21,7 +22,7 @@ used to open the vault. This public key will be saved in the `evaluation_system`
 backend root directory. Only if saved this key and the key in the vault match,
 secrets can be retrieved. Therefore it might be a good idea to deploy,
 the mariadb server (and with it the vault) and the `evaluation_system`
-backend togehter.
+backend together.
 
 On *CentOS* python SELinux libraries need to be installed. If you choose to
 install ansible via the `install_ansible` you'll have to use `conda` to
@@ -31,9 +32,9 @@ For example : `conda install -c conda-forge  libselinux-cos7-x86_64`
 # Pre-Requisites
 The main work will be done by
 [ansible](https://docs.ansible.com/ansible/latest/index.html), hence some level
-of familiarity with ansible is advantagous. Since we are using ansible we can
+of familiarity with ansible is advantageous. Since we are using ansible we can
 use this deployment routine from a workstation computer (like a Mac-book).
-You do not need to run the depoyment on the machines where things get installed.
+You do not need to run the deployment on the machines where things get installed.
 The only requirement is that you have to setup ansible and you can establish
 ssh connections to the servers.
 ### Preparation on windows based system (without wsl).
@@ -41,7 +42,7 @@ Currently ansible is not natively available on windows based systems. You can us
 the unix runtime environment [cygwin](https://www.cygwin.com) to download
 and install the needed software. Just follow the steps listed on the web page
 to setup cygwin on your windows system. In order to be able to install the
-freva deployment programm you'll first need to install the following packages
+freva deployment program you'll first need to install the following packages
 via cygwin:
 
 - python3
@@ -79,6 +80,7 @@ python3 -m pip install libselinux-python3
 
 ## Commands after installation:
 The `pip install` command will create *four* different commands:
+
 - `deploy-freva-map`: To setup a service that keeps track of all deployed
    freva instances and their services.
 - `deploy-freva`: Text user interface to configure and run the deployment.
@@ -209,7 +211,7 @@ Deploy freva and its services on different machines.
 options:
   -h, --help            show this help message and exit
   --server-map SERVER_MAP
-                        Hostname of the service mapping the freva server archtiecture, Note: you can create a server map by running
+                        Hostname of the service mapping the freva server architecture, Note: you can create a server map by running
                         the deploy-freva-map command (default: None)
   --config CONFIG, -c CONFIG
                         Path to ansible inventory file. (default: /home/wilfred/.config/freva/deployment/inventory.toml)
@@ -242,7 +244,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   --server-map SERVER_MAP
-                        Hostname of the service mapping the freva server archtiecture, Note: you can create a server map by running
+                        Hostname of the service mapping the freva server architecture, Note: you can create a server map by running
                         the deploy-freva-map command (default: None)
   --services {web,db,solr} [{web,db,solr} ...]
                         The services to be started|stopped|restarted|checked (default: ['solr', 'db', 'web'])

--- a/assets/share/freva/deployment/config/inventory.toml
+++ b/assets/share/freva/deployment/config/inventory.toml
@@ -1,11 +1,11 @@
-# This is the "defaut" freva deployment configuration file.
+# This is the "default" freva deployment configuration file.
 #
 #   - The files syntax follows the `toml` markup language (https://toml.io)
 #   - Comments begin with the "#" character
 #   - Blank lines are ignored
 #   - Groups of hosts are delimited by [header] elements
 #   - The groups define different deployment steps
-#   - Additional configuration for each group is set in the confg section
+#   - Additional configuration for each group is set in the config section
 #     of each header -> [header.config]
 #   - You can enter hostnames or ip addresses
 #   - A hostname/ip can be a member of multiple groups
@@ -18,8 +18,8 @@
 # NOTE: this key has to be the first in the file
 project_name = ""
 
-## Set the path to the SSL certfificate files that is used to make password
-## queries to the vault server or used as web certfificates.
+## Set the path to the SSL certificate files that is used to make password
+## queries to the vault server or used as web certificates.
 [certificates]
 
 ## Path to the public keyfile
@@ -76,7 +76,7 @@ db = ""
 ##If you need a different user name you can set it here:
 #ansible_user = "username"
 
-## You can set the db_host seperately, if none is given (default)
+## You can set the db_host separately, if none is given (default)
 ## the one from the hostsnames above are taken
 
 db_host = ""
@@ -92,7 +92,7 @@ ansible_become_user = "root"
 #ansible_python_interpreter="/usr/bin/python3"
 
 ##Indicate whether or not to empty any pre-existing folders/docker volumes.
-##(Useful for a truely fresh start) (default: False)
+##(Useful for a truly fresh start) (default: False)
 wipe = false
 
 ## In case you want to set a custom path to a ansible playbook,
@@ -121,7 +121,7 @@ ansible_become_user = "root"
 #ansible_user = "username"
 
 ##Indicate whether or not to empty any pre-existing folders/docker volumes.
-##(Useful for a truely fresh start) (default: False)
+##(Useful for a truly fresh start) (default: False)
 wipe = false
 ## In case you want to set a custom path to a ansible playbook,
 ## you can do this here, by default the deployment will use the playbook
@@ -141,7 +141,7 @@ admins = ""
 install_dir=""
 
 ## Set the path to any existing conda executable on the target machine,
-## if not existing (default) a tmporary conda distribution will be downloaded
+## if not existing (default) a temporary conda distribution will be downloaded
 conda_exec_path=""
 
 ## The directory where the project configuration files will be stored, leave
@@ -167,12 +167,12 @@ preview_path = ""
 ## "local", "slurm", "pbs", "lfs", "moab", "oar", "sge"
 scheduler_system = "local"
 
-## Set the path to the directory that containes the stdout of the plugings,
+## Set the path to the directory that contains the stdout of the plugins,
 ## this directory must be accessible to the web ui. The workload manager
 ## will write the stdout into this directory. Defaults to ${base_dir_location}/share
 scheduler_output_dir = ""
 
-# Set the target architecutre of the system where the backend will be installed
+# Set the target architecture of the system where the backend will be installed
 # to. You can choose from the following options:
 # Linux-x86_64 (default), Linux-aarch64, Linux-ppc64le, Linux-s390x, MacOSX-x86_64
 arch = "Linux-x86_64"
@@ -188,12 +188,12 @@ arch = "Linux-x86_64"
 ## Ansible needs a python3 interpreter, which can be set for custom python3 instances
 #ansible_python_interpreter = ""
 
-## The core deployment needs git, if git is not in the default PATH vraiable
+## The core deployment needs git, if git is not in the default PATH variable
 ## you can set the path to the git executable
 #git_path = ""
 
 ##Indicate whether or not to empty any pre-existing folders/docker volumes.
-##(Useful for a truely fresh start) (default: False)
+##(Useful for a truly fresh start) (default: False)
 wipe = false
 
 ## In case you want to set a custom path to a ansible playbook,
@@ -274,7 +274,7 @@ ldap_last_name_field = "givenname"
 ## Set ldap first name search key
 ldap_first_name_field = "sn"
 
-## Set ldap email earch key
+## Set ldap email search key
 ldap_email_name_field = "mail"
 
 ## Set the ldap group class name

--- a/assets/share/freva/deployment/playbooks/core-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/core-server-playbook.yml
@@ -17,7 +17,7 @@
       file:
         state: absent
         path: /tmp/evaluation_system
-    - name: Cloning the evluation_system reposiotry
+    - name: Cloning the evaluation_system repository
       git:
         repo: "{{ core_git_url }}"
         dest: /tmp/evaluation_system
@@ -72,11 +72,11 @@
       when: core_preview_path | length != 0
       become: "{{use_become}}"
       ignore_errors: true
-    - name: Registering evaluation_sytem path
+    - name: Registering evaluation_system path
       stat:
         path: "{{ core_root_dir }}/freva/evaluation_system.conf"
       register: eval_conf
-    - name: Inserting evaluation_sytem.conf file without admin group
+    - name: Inserting evaluation_system.conf file without admin group
       copy:
         src: "{{ core_dump }}"
         dest: "{{ core_root_dir }}/freva/evaluation_system.conf"
@@ -98,7 +98,7 @@
         EVALUATION_SYSTEM_CONFIG_FILE: "/tmp/evaluation_system/evaluation_system.conf"
       when: (core_install is true)
       become: "{{use_become}}"
-    - name: Inserting evaluation_sytem.conf file with admin group
+    - name: Inserting evaluation_system.conf file with admin group
       copy:
         src: "{{ core_dump }}"
         dest: "{{ core_root_dir }}/freva/evaluation_system.conf"

--- a/assets/share/freva/deployment/playbooks/db-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/db-server-playbook.yml
@@ -37,7 +37,7 @@
         -v /root/freva-service-config/mysql/daily_backup.sh:/usr/local/bin/daily_backup:z
         -v /tmp/reset_root_pw.sh:/tmp/reset_root_pw.sh:z
         -t docker.io/mariadb:latest mariadbd-safe --skip-grant-tables
-    continer_name: "{{ db_name }}"
+    container_name: "{{ db_name }}"
     vault_name: "{{project_name}}-vault"
     use_become: "{{ db_ansible_become_user is defined and db_ansible_become_user != '' }}"
   tasks:

--- a/assets/share/freva/deployment/playbooks/server-map-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/server-map-playbook.yml
@@ -23,7 +23,7 @@
       shell: systemctl stop freva-map; systemctl stop freva-map; echo 0
       when: wipe == true
     - pause: seconds=2
-    - name: Deleting existing contianer
+    - name: Deleting existing container
       shell: >
         /tmp/docker-or-podman stop freva-map;
         /tmp/docker-or-podman rm freva-map;

--- a/assets/share/freva/deployment/playbooks/solr-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/solr-server-playbook.yml
@@ -3,7 +3,7 @@
 
   vars:
     ansible_python_interpreter: "{{ solr_ansible_python_interpreter }}"
-    continer_name: "{{ solr_name }}"
+    container_name: "{{ solr_name }}"
     docker_cmd: >
         -e CORE=files
         -e NUM_BACKUPS=7
@@ -97,7 +97,7 @@
         sh /tmp/solr_service/create_cron.sh "{{ solr_name }}" "{{solr_email}}"
       when: systemctl.stat.exists == true
       become: "{{use_become}}"
-    - name: Deleting tmporary files
+    - name: Deleting temporary files
       file:
         path: "{{item}}"
         state: absent

--- a/assets/share/freva/deployment/playbooks/vault-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/vault-server-playbook.yml
@@ -3,7 +3,7 @@
 
   vars:
     ansible_python_interpreter: "{{ db_ansible_python_interpreter }}"
-    continer_name: "{{ vault_name }}"
+    container_name: "{{ vault_name }}"
     docker_cmd: >
         --net {{ project_name }} --cap-add=IPC_LOCK
         --dns 8.8.8.8
@@ -29,7 +29,7 @@
       stat:
         path: /usr/bin/systemctl
       register: vault_volume
-    - name: Set vault valume path
+    - name: Set vault volume path
       set_fact:
         exists: vault_volume.stat.exists
     - name: Stopping services and deleting existing containers

--- a/assets/share/freva/deployment/playbooks/web-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/web-server-playbook.yml
@@ -20,7 +20,7 @@
         /tmp/docker-or-podman exec -it {{ vault_name }}
         vault kv put kv/email username={{vault_email_user}}
         password='{{vault_email_password}}'
-    - name: Deleting tmporary files
+    - name: Deleting temporary files
       file:
         path: "{{item}}"
         state: absent
@@ -188,7 +188,7 @@
         - "{{apache_name}}"
         - "{{web_name}}"
       when: systemctl.stat.exists == true
-    - name: Deleting tmporary files
+    - name: Deleting temporary files
       file:
         path: "{{item}}"
         state: absent

--- a/assets/share/freva/deployment/scripts/create_systemd.py
+++ b/assets/share/freva/deployment/scripts/create_systemd.py
@@ -24,7 +24,7 @@ SYSTEMD_TMPL = dict(
 
 
 def parse_args() -> Tuple[str, str, List[str], bool]:
-    """Parse the commandline arguments."""
+    """Parse the command-line arguments."""
 
     app = argparse.ArgumentParser(
         prog=sys.argv[0], description="Create a new systemd unit."

--- a/assets/share/freva/deployment/scripts/docker-or-podman
+++ b/assets/share/freva/deployment/scripts/docker-or-podman
@@ -56,14 +56,14 @@ class CommandFactory(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        sub_commnds: str
+        sub_command: str
             The sub command that is passed to the container command.
         *flags: str
             Additional command line arguments passed to the container command.
 
         Returns
         -------
-        list[str]: Constructed command line arguemnts.
+        list[str]: Constructed command line arguments.
         """
         return [self.get_container_cmd(), sub_command] + list(flags)
 
@@ -100,7 +100,7 @@ class CommandFactory(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        list[str]: Constructed commmand line arguments.
+        list[str]: Constructed command line arguments.
         """
 
         cli_command = [self.get_container_cmd(), "pull"]
@@ -118,7 +118,7 @@ class CommandFactory(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        list[str]: Constructed commmand line arguments.
+        list[str]: Constructed command line arguments.
         """
 
         cli_command = [self.get_container_cmd(), sub_command, "-f"]
@@ -145,7 +145,7 @@ class CommandFactory(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        list[str]: Constructed commmand line arguments.
+        list[str]: Constructed command line arguments.
         """
 
         cli_command = [self.get_container_cmd(), sub_command]
@@ -201,7 +201,7 @@ class Apptainer(CommandFactory):
 
         Returns
         -------
-        list[str]: Constructed commmand line arguments.
+        list[str]: Constructed command line arguments.
         """
         cli_command = [self.get_container_cmd(), "pull", "-F"]
         return cli_command + self.images
@@ -218,7 +218,7 @@ class Apptainer(CommandFactory):
 
         Returns
         -------
-        list[str]: Constructed commmand line arguments.
+        list[str]: Constructed command line arguments.
         """
 
         if sub_command == "rmi":
@@ -323,7 +323,7 @@ def parse_args() -> List[str]:
     """Construct a command line argument parser."""
 
     parser = argparse.ArgumentParser(
-        prog=sys.argv[0], description="Container wrapper programm"
+        prog=sys.argv[0], description="Container wrapper program"
     )
     parser.add_argument(
         "-p",

--- a/assets/share/freva/deployment/servers/restservice.py
+++ b/assets/share/freva/deployment/servers/restservice.py
@@ -26,7 +26,7 @@ class ServerBaseClass:
 
     @property
     def server_info_file(self) -> Path:
-        """Path to the filename holding the server infromation."""
+        """Path to the filename holding the server information."""
         return Path(os.environ["SERVER_FILE"])
 
     def update_server_information(self) -> None:
@@ -131,19 +131,19 @@ class ServerEntry(ServerBaseClass, Resource):
 
 
 class ServerStaus(Resource):
-    """Get and set the staus of services."""
+    """Get and set the status of services."""
 
     service_status: dict[str, dict[str, dict[str, str]]] = {}
 
     def get(self, project: str, service: str) -> tuple[dict[str, str], int]:
-        """Get method for retreivng the service status.
+        """Get method for retrieving the service status.
 
         Parameters
         ----------
         project: str
             The freva project name which is updated.
         service: str
-            Name of the service which status is retreived
+            Name of the service which status is retrieved
         """
         try:
             return self.service_status[project][service], 200

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -8,7 +8,7 @@ The Free evaluation system framework (Freva) consists of three basic parts:
 - command line interface and a python client as user interface to the core library.
 - services, such as a apache solr data search service, mariadb database and web service providing a web-based user interface (web ui) to the core library
 
-Command line interface, python client and web ui make use of the core library, the core library on the other hand makes use of the apache solr and mariadb services. This hierachy is outlined in the figure below:
+Command line interface, python client and web ui make use of the core library, the core library on the other hand makes use of the apache solr and mariadb services. This hierarchy is outlined in the figure below:
 
 ![](Concept_Map.png)
 

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -9,7 +9,7 @@ A complete Freva instance will need the following services:
 ## Setting the python and git path
 Some systems do not have access to python3.4+ (/usr/bin/python3) or git by default.
 In such cases you can overwrite the `ansible_python_interpreter` in the inventory
-settings of the server section to point ansible to a custom `python3` bindary. For example
+settings of the server section to point ansible to a custom `python3` binary. For example
 
 ```
 ansible_python_interpreter=/sw/spack-rhel6/miniforge3-4.9.2-3-Linux-x86_64-pwdbqi/bin/python3

--- a/docs/Folders.md
+++ b/docs/Folders.md
@@ -32,7 +32,7 @@ project_website=
 # of the python environment
 root_dir=
 #
-# The location of the work direcotry for is user specific data
+# The location of the work directory for is user specific data
 base_dir_location=${root_dir}/freva_output
 #
 

--- a/docs/Transition.md
+++ b/docs/Transition.md
@@ -29,7 +29,7 @@ options:
   -h, --help           show this help message and exit
   --old-port OLD_PORT  The port where the old database server is running on. (default: 3306)
   --old-db OLD_DB      The name of the old database (default: evaluationsystem)
-  --old-pw OLD_PW      The passowrd to the old database (default: None)
+  --old-pw OLD_PW      The password to the old database (default: None)
   --old-user OLD_USER  The old database user (default: evaluationsystem)
 ```
 
@@ -51,10 +51,10 @@ In the old version the DRS (Date Reference Syntax) File configuration,
 that is the definitions of dataset metadata, was hard coded into the module
 `evaluation_system.model.file`. In the new version this configuration
 is saved in a designated [toml](https://toml.io/en/) file (drs_config.toml).
-The ingestion of data is done by the new `freva-ingest` software, which is
-written in rust. More information on this configuration and usage of the
+The ingestion of data is done by the new `data-crawler` software, also written in python.
+More information on this configuration and usage of the
 ingestion software can be found on the
-[README](https://gitlab.dkrz.de/freva/freva-ingest).
+[README](https://freva.gitlab-pages.dkrz.de/metadata-crawler-source/).
 
 
 
@@ -140,7 +140,7 @@ Python plugins (especially python2) need special care. The recommended strategy
 is to convert the plugin content to python3. If this is not possible an anaconda
 python2 environment should be created.
 
-If in the original plugin the plugin code is directly executed in the `run_rool`
+If in the original plugin the plugin code is directly executed in the `run_tool`
 method (formerly named `runTool`) this code has to be split from the new `run_tool` method. The
 transition strategy is gathering the essential information in a `json` file that
 is passed to the actual core part of the plugin. The code below shows a simple

--- a/docs/TuiHowto.md
+++ b/docs/TuiHowto.md
@@ -199,7 +199,7 @@ vault service that gets deployed when setting up the database.
 
 
 ## Solr server setup
-The third screen configures the setup apache solr serch server. At the top of
+The third screen configures the setup apache solr search server. At the top of
 the screen you'll see a tick box, which indicates whether or not this step is
 used for deployment. If this box is *un*ticked - tick/untick using the
 `<SPACE>` key - the deployment will skip the setup of solr entirely. The

--- a/src/freva_deployment/__init__.py
+++ b/src/freva_deployment/__init__.py
@@ -11,7 +11,7 @@ AVAILABLE_CONDA_ARCHS = [
 ]
 
 
-def download_auxiliry_data():
+def download_auxiliary_data():
     """Download any data that needs to be downloaded."""
 
     def reporthook(count, block_size, total_size):
@@ -39,4 +39,4 @@ def download_auxiliry_data():
 
 
 if __name__ == "__main__":
-    download_auxiliry_data()
+    download_auxiliary_data()

--- a/src/freva_deployment/cli/_deploy.py
+++ b/src/freva_deployment/cli/_deploy.py
@@ -12,7 +12,7 @@ from ..utils import config_dir, guess_map_server, set_log_level
 
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
-    """Consturct command line argument parser."""
+    """Construct command line argument parser."""
 
     ap = argparse.ArgumentParser(
         prog="deploy-freva-cmd",
@@ -25,7 +25,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=None,
         help=(
             "Hostname of the service mapping the freva server "
-            "archtiecture, Note: you can create a server map by "
+            "architecture, Note: you can create a server map by "
             "running the deploy-freva-map command"
         ),
     )

--- a/src/freva_deployment/cli/_migrate.py
+++ b/src/freva_deployment/cli/_migrate.py
@@ -62,7 +62,7 @@ def exec_command(
 
 
 def execute_script_and_get_config(python_bin: Path, template: str) -> str:
-    """Execute a python2 template and read it's ouput."""
+    """Execute a python2 template and read it's output."""
     logger.debug("Working on %s", python_bin)
     python_path = python_bin.parents[3] / "freva" / "src"
     with TemporaryDirectory() as temp_dir:
@@ -120,7 +120,7 @@ def _migrate_db(parser: argparse.Namespace) -> None:
     db_host = parser.new_hostname
     mysqldump = shutil.which("mysqldump")
     if mysqldump is None:
-        logger.error("myslqdump not found, to continue isntall mysqldump")
+        logger.error("myslqdump not found, to continue install mysqldump")
         return
     new_db_cfg = read_db_credentials(parser.cert_file, db_host)
     with NamedTemporaryFile(suffix=".sql") as temp_file:
@@ -213,7 +213,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--old-pw",
         type=str,
         default=None,
-        help="The passowrd to the old database",
+        help="The password to the old database",
     )
     db_parser.add_argument(
         "--old-user",

--- a/src/freva_deployment/cli/_server_map.py
+++ b/src/freva_deployment/cli/_server_map.py
@@ -20,7 +20,7 @@ from ..utils import asset_dir, logger
 
 
 def parse_args(args: list[str]) -> argparse.Namespace:
-    """Consturct command line argument parser."""
+    """Construct command line argument parser."""
     app = argparse.ArgumentParser(
         prog="deploy-freva-map",
         description="Create service that maps the freva server architecture.",

--- a/src/freva_deployment/cli/_service.py
+++ b/src/freva_deployment/cli/_service.py
@@ -27,7 +27,7 @@ from ..utils import (
 
 
 def parse_args(args: list[str]) -> argparse.Namespace:
-    """Consturct command line argument parser."""
+    """Construct command line argument parser."""
     app = argparse.ArgumentParser(
         prog="freva-service",
         description="Interact with installed freva services.",
@@ -52,7 +52,7 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         default=None,
         help=(
             "Hostname of the service mapping the freva server "
-            "archtiecture, Note: you can create a server map by "
+            "architecture, Note: you can create a server map by "
             "running the deploy-freva-map command"
         ),
     )

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -422,7 +422,7 @@ class DeployFactory:
             config[step]["vars"][f"{step}_dump"] = str(dump_file)
 
     def parse_config(self) -> str:
-        """Create config files for anisble and evaluation_system.conf."""
+        """Create config files for ansible and evaluation_system.conf."""
         logger.info("Parsing configurations")
         self._check_config()
         config: dict[str, dict[str, dict[str, str | int | bool]]] = {}
@@ -447,7 +447,7 @@ class DeployFactory:
 
     @property
     def python_prefix(self) -> Path:
-        """Get the path of the new conda evnironment."""
+        """Get the path of the new conda environment."""
         return Path(sys.exec_prefix) / "bin" / "python3"
 
     @property
@@ -462,7 +462,7 @@ class DeployFactory:
 
     @property
     def steps(self) -> list[str]:
-        """Set all the deploment steps."""
+        """Set all the deployment steps."""
         steps = []
         for step in self._steps:
             steps.append(step)
@@ -486,7 +486,7 @@ class DeployFactory:
             yaml.dump(playbook, f_obj)
 
     def create_eval_config(self) -> None:
-        """Create and dump the evaluation_systme.config."""
+        """Create and dump the evaluation_system.config."""
         logger.info("Creating evaluation_system.conf")
         keys = (
             ("core", "admins"),
@@ -563,7 +563,7 @@ class DeployFactory:
             infrastructure, if None given (default) no new deployed services
             are added.
         ask_pass: bool, default: True
-            Instruct Ansible to ask for the ssh passord instead of using a
+            Instruct Ansible to ask for the ssh password instead of using a
             ssh key
         verbosity: int, default: 0
             Verbosity level, default 0

--- a/src/freva_deployment/ui/deployment_tui/base.py
+++ b/src/freva_deployment/ui/deployment_tui/base.py
@@ -19,18 +19,18 @@ logger: logging.Logger = logging.getLogger("deploy-freva-tui")
 class FileSelector(npyscreen.FileSelector):
     """FileSelector widget that allows for filtering file extensions."""
 
-    file_extentions: list[str]
+    file_extensions: list[str]
     """List of allowed file extensions."""
     value: str
     """The value of this file selector."""
 
     def __init__(
-        self, *args, file_extentions: str | list[str] = [".toml"], **kwargs
+        self, *args, file_extensions: str | list[str] = [".toml"], **kwargs
     ) -> None:
-        if isinstance(file_extentions, str):
-            self.file_extentions = [file_extentions]
+        if isinstance(file_extensions, str):
+            self.file_extensions = [file_extensions]
         else:
-            self.file_extentions = file_extentions
+            self.file_extensions = file_extensions
         super().__init__(*args, **kwargs)
         self.how_exited_handers[npyscreen.wgwidget.EXITED_ESCAPE] = self.exit
 
@@ -59,7 +59,7 @@ class FileSelector(npyscreen.FileSelector):
                 if not rel_path.startswith("."):
                     if fn.is_dir():
                         dir_list.append(str(fn) + os.sep)
-                    elif fn.suffix in self.file_extentions:
+                    elif fn.suffix in self.file_extensions:
                         file_list.append(str(fn))
         except OSError:
             npyscreen.notify_wait(
@@ -99,7 +99,7 @@ class BaseForm(npyscreen.FormMultiPageWithMenus, npyscreen.FormWithMenus):
 
     _num: int = 0
     input_fields: dict[str, tuple[npyscreen.TitleText, bool]] = {}
-    """Dictionary of input fileds: the key of the dictionary represents the name
+    """Dictionary of input fields: the key of the dictionary represents the name
        of the key in the in config toml input files. Values represent a tuple of
        npysceen types that display the input information on this key to the
        user and a boolean indicating whether or not this variable is mandatory.

--- a/src/freva_deployment/ui/deployment_tui/deploy_forms.py
+++ b/src/freva_deployment/ui/deployment_tui/deploy_forms.py
@@ -129,7 +129,7 @@ class CoreScreen(BaseForm):
             scheduler_output_dir=(
                 self.add_widget_intelligent(
                     npyscreen.TitleText,
-                    name=f"{self.num}Ouput dir. of the scheduler system, "
+                    name=f"{self.num}Output dir. of the scheduler system, "
                     "${base_dir_location}/share",
                     value=cfg.get("scheduler_output_dir", ""),
                 ),
@@ -375,7 +375,7 @@ class WebScreen(BaseForm):
             homepage_heading=(
                 self.add_widget_intelligent(
                     npyscreen.TitleText,
-                    name=f"{self.num}A brief describtion of the project:",
+                    name=f"{self.num}A brief description of the project:",
                     value=cfg.get("homepage_heading", "Lorem ipsum dolor sit amet"),
                 ),
                 True,

--- a/src/freva_deployment/ui/deployment_tui/main_window.py
+++ b/src/freva_deployment/ui/deployment_tui/main_window.py
@@ -51,7 +51,7 @@ class MainApp(npyscreen.NPSAppManaged):
         self.config = cast(Dict[str, Any], self._read_cache("config", {}))
         for step in self._steps_lookup.keys():
             self.config.setdefault(step, {"hosts": "", "config": {}})
-        self._add_froms()
+        self._add_forms()
 
     def reset(self) -> None:
         npyscreen.blank_terminal()
@@ -63,7 +63,7 @@ class MainApp(npyscreen.NPSAppManaged):
         self._save_thread.daemon = True
         self._save_thread.start()
 
-    def _add_froms(self) -> None:
+    def _add_forms(self) -> None:
         """Add forms to edit the deploy steps to the main window."""
         self._forms["core"] = self.addForm(
             "MAIN",
@@ -122,10 +122,10 @@ class MainApp(npyscreen.NPSAppManaged):
                 pass
 
     def save_dialog(self, *args, **kwargs) -> None:
-        """Create a dialoge that allows for saving the config file."""
+        """Create a dialog that allows for saving the config file."""
 
         the_selected_file = selectFile(
-            select_dir=False, must_exist=False, file_extentions=[".toml"]
+            select_dir=False, must_exist=False, file_extensions=[".toml"]
         )
         if the_selected_file:
             the_selected_file = Path(the_selected_file).with_suffix(".toml")
@@ -145,14 +145,14 @@ class MainApp(npyscreen.NPSAppManaged):
         self.resetHistory()
         self.editing = True
         self.switchFormNow()
-        self._add_froms()
+        self._add_forms()
         self._setup_form.inventory_file.value = config_file
 
     def load_dialog(self, *args, **kwargs) -> None:
-        """Create a dialoge that allows for loading a config file."""
+        """Create a dialog that allows for loading a config file."""
 
         the_selected_file = selectFile(
-            select_dir=False, must_exist=True, file_extentions=[".toml"]
+            select_dir=False, must_exist=True, file_extensions=[".toml"]
         )
         if the_selected_file:
             self._update_config(the_selected_file)

--- a/src/freva_deployment/utils.py
+++ b/src/freva_deployment/utils.py
@@ -30,10 +30,10 @@ config_text = """
 [general]
 [variables]
 ### you can set here different *global* variables that are
-### evaluatated in the deployment configurations. For example
+### evaluated in the deployment configurations. For example
 ### if you set here the variable USER = "foo" then you can
 ### use the this defined variable in the inventory file to
-### set the ansible user: anisble_user="${USER}"
+### set the ansible user: ansible_user="${USER}"
 
 # USER="myusername"
 # USER_GROUP = "myusergroup"
@@ -246,7 +246,7 @@ def download_server_map(
     Parameters
     ----------
     server_map: str,
-        The hostname holding the server archtiecture information.
+        The hostname holding the server architecture information.
     Returns
     -------
     dict[str, list[NamedTuple("service", [("name", str), ("python_path", str),
@@ -272,12 +272,12 @@ def upload_server_map(
     project_name: str,
     deployment_setup: dict[str, dict[str, str]],
 ) -> None:
-    """Upload server information to service that stores server archtiecture.
+    """Upload server information to service that stores server architecture.
 
     Parameters
     ----------
     server_map: str
-        The hostname holding the server archtiecture information.
+        The hostname holding the server architecture information.
     project_name: str
         Name of the freva project
     deployment_setup: dict[str, str]
@@ -319,12 +319,12 @@ def get_email_credentials() -> tuple[str, str]:
 
 
 def get_passwd(min_characters: int = 8) -> str:
-    """Create a secure pasword.
+    """Create a secure password.
 
     Parameters
     ==========
     min_characters:
-        The minimum lenght of the password (default 8)
+        The minimum length of the password (default 8)
 
     Returns
     =======


### PR DESCRIPTION
mostly harmless typos in docu.

I found a couple of typos in the ansible [playbook variables](https://github.com/FREVA-CLINT/freva-deployment/blob/main/assets/share/freva/deployment/playbooks/db-server-playbook.yml#L40):
```
    continer_name: "{{ db_name }}"
```
to 
```
    container_name: "{{ db_name }}"
```
etc.

I do not know if this variables are standard ones or not in Ansible, but just in case I cahnged them everywhere
