### PR TITLE
Bump databrowser version to 2403.0.2

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -7,6 +7,12 @@ What's new
    :maxdepth: 0
    :titlesonly:
 
+v2403.1.0
+~~~~~~~~
+* Bumped version of databrowserAPI to 2403.0.2
+
+
+
 
 v2403.0.5
 ~~~~~~~~~

--- a/src/freva_deployment/__init__.py
+++ b/src/freva_deployment/__init__.py
@@ -1,6 +1,6 @@
 from urllib.request import urlretrieve
 
-__version__ = "2403.0.5"
+__version__ = "2403.1.0"
 FREVA_PYTHON_VERSION = "3.11"
 AVAILABLE_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 AVAILABLE_CONDA_ARCHS = [


### PR DESCRIPTION
This PR auto bumps the version of databrowserto 2403.0.2. After the PR was merged you can create a new release of the deployment software by creating a tag with the name v2403.0.2 or, better running`tox -e release` on a local copy of the software.