### PR TITLE
Migrate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,9 @@ and save existing configurations you can mount the directories of the config
 files into the container.
 
 ## Commands after installation:
-The `pip install` command will create *four* different commands:
-- `deploy-freva-map`: To setup a service that keeps track of all deployed
-   freva instances and their services.
+The `pip install` command will create *three* different commands:
 - `deploy-freva`: Text user interface to configure and run the deployment.
 - `deploy-freva-cmd`: Run already configured deployment.
-- `freva-service`: Start|Stop|Restart|Check services of freva instances.
 - `freva-migrate`: Command line interface to manage project migration from
    old freva systems to new ones.
 If you can't find the commands mentioned above pip was probably installing
@@ -86,7 +83,7 @@ export PATH=$PATH:$HOME/.local/bin
 Because the services of MariaDB, DatabrowserAPI and Apache httpd will be deployed
 on docker container images, docker needs to be available on the target servers.
 Since version *v2309.0.0* of the deployment the containers are set up
-using `doker-compose`. Hence `docker-compose` (or `podman-compose`) has to be
+using `docker-compose`. Hence `docker-compose` (or `podman-compose`) has to be
 installed on the host systems. Usually installing and running docker
 requires *root* privileges. Hence, on the servers that will be running docker
 you will need root access. There exists an option to install and run docker
@@ -157,7 +154,7 @@ If you already have a configuration saved in a toml base inventory file you can
 issue the `deploy-freva-cmd` command:
 
 ```bash
-eploy-freva-cmd --help
+deploy-freva-cmd --help
 usage: deploy-freva-cmd [-h] [--config CONFIG] [--steps {web,core,db,databrowser} [{web,core,db,databrowser} ...]] [--ask-pass] [--ssh-port SSH_PORT] [-v] [-l]
                         [--gen-keys] [-V]
 
@@ -181,7 +178,7 @@ options:
 
 The `--steps` flags can be used if not all services should be deployed.
 
-# Kown Issues:
+# Known Issues:
 Below are possible solutions to some known issues:
 
 ### SSH connection fails:
@@ -289,7 +286,7 @@ The following command will install freva along all with it's components to
 the local VM:
 
 ```console
-deploy-freva-cmd  assets/share/freva/deployment/config/inventory.toml --gen-keys --ssh-port 2222
+deploy-freva-cmd  --config assets/share/freva/deployment/config/inventory.toml --gen-keys --ssh-port 2222
 ```
 
 If you want to tear down the created VM you can either press CTRL+C in the

--- a/src/freva_deployment/cli/_migrate.py
+++ b/src/freva_deployment/cli/_migrate.py
@@ -129,7 +129,16 @@ def _migrate_db(parser: argparse.Namespace) -> None:
                 "--tz-utc --no-create-db "
                 f"{parser.old_db}"
             )
-            exec_command(dump_command, stdout=f_obj)
+            try:
+                exec_command(dump_command, stdout=f_obj)
+            except CalledProcessError as error:
+                if "Unknown table \\'COLUMN_STATISTICS\\'" in str(
+                    error.stderr
+                ):
+                    dump_command = dump_command + " --column-statistics=0 "
+                    exec_command(dump_command, stdout=f_obj)
+                else:
+                    raise error
             _add_new_db(new_db_cfg, temp_file.name)
 
 

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -85,7 +85,9 @@ class DeployFactory:
         self._master_pass: str = ""
         self.email_password: str = ""
         self._td: RunnerDir = RunnerDir()
-        self.eval_conf_file: Path = self._td.parent_dir / "evaluation_system.conf"
+        self.eval_conf_file: Path = (
+            self._td.parent_dir / "evaluation_system.conf"
+        )
         self.web_conf_file: Path = self._td.parent_dir / "freva_web.toml"
         self.apache_config: Path = self._td.parent_dir / "freva_web.conf"
         self._db_pass: str = ""
@@ -168,12 +170,12 @@ class DeployFactory:
         """Prepare the vault."""
         self.cfg["vault"]["config"].setdefault("ansible_become_user", "root")
         self.cfg["vault"]["config"].pop("db_playbook", "")
-        self.cfg["vault"]["config"]["db_port"] = self.cfg["vault"]["config"].get(
-            "port", 3306
-        )
-        self.cfg["vault"]["config"]["db_user"] = self.cfg["vault"]["config"].get(
-            "user", ""
-        )
+        self.cfg["vault"]["config"]["db_port"] = self.cfg["vault"][
+            "config"
+        ].get("port", 3306)
+        self.cfg["vault"]["config"]["db_user"] = self.cfg["vault"][
+            "config"
+        ].get("user", "")
         self.cfg["vault"]["config"]["root_passwd"] = self.master_pass
         self.cfg["vault"]["config"]["passwd"] = self.db_pass
         self.cfg["vault"]["config"]["keyfile"] = self.public_key_file
@@ -200,7 +202,9 @@ class DeployFactory:
         )
         self.cfg["db"]["config"]["data_path"] = str(data_path)
         for key in ("name", "user", "db"):
-            self.cfg["db"]["config"][key] = self.cfg["db"]["config"].get(key) or "freva"
+            self.cfg["db"]["config"][key] = (
+                self.cfg["db"]["config"].get(key) or "freva"
+            )
         db_host = self.cfg["db"]["config"].get("host", "").strip()
         if not db_host:
             self.cfg["db"]["config"]["host"] = host
@@ -215,13 +219,17 @@ class DeployFactory:
     def _prep_freva_rest(self, prep_web=True) -> None:
         """prepare the freva_rest service."""
         self._config_keys.append("freva_rest")
-        self.cfg["freva_rest"]["config"].setdefault("ansible_become_user", "root")
+        self.cfg["freva_rest"]["config"].setdefault(
+            "ansible_become_user", "root"
+        )
         self.cfg["freva_rest"]["config"]["root_passwd"] = self.master_pass
         self.cfg["freva_rest"]["config"].pop("core", None)
         data_path = Path(
             cast(
                 str,
-                self.cfg["freva_rest"]["config"].get("data_path", "/opt/freva"),
+                self.cfg["freva_rest"]["config"].get(
+                    "data_path", "/opt/freva"
+                ),
             )
         )
         self.cfg["freva_rest"]["config"]["data_path"] = str(data_path)
@@ -232,9 +240,9 @@ class DeployFactory:
             self.cfg["freva_rest"]["config"][key] = (
                 self.cfg["freva_rest"]["config"].get(key) or default
             )
-        self.cfg["freva_rest"]["config"]["email"] = self.cfg["web"]["config"].get(
-            "contacts", ""
-        )
+        self.cfg["freva_rest"]["config"]["email"] = self.cfg["web"][
+            "config"
+        ].get("contacts", "")
         if prep_web:
             self._prep_web(False)
 
@@ -242,7 +250,9 @@ class DeployFactory:
         """prepare the core deployment."""
         self._config_keys.append("core")
         self.cfg["core"]["config"].setdefault("ansible_become_user", "")
-        self.playbooks["core"] = self.cfg["core"]["config"].get("core_playbook")
+        self.playbooks["core"] = self.cfg["core"]["config"].get(
+            "core_playbook"
+        )
         # Legacy args as we are going to use micromamba
         self.cfg["core"]["config"]["arch"] = (
             self.cfg["core"]["config"]
@@ -258,7 +268,9 @@ class DeployFactory:
         if not self.cfg["core"]["config"]["admins"]:
             self.cfg["core"]["config"]["admins"] = getuser()
         install_dir = Path(self.cfg["core"]["config"]["install_dir"])
-        root_dir = Path(self.cfg["core"]["config"].get("root_dir", "") or install_dir)
+        root_dir = Path(
+            self.cfg["core"]["config"].get("root_dir", "") or install_dir
+        )
         self.cfg["core"]["config"]["install_dir"] = str(install_dir)
         self.cfg["core"]["config"]["root_dir"] = str(root_dir)
         preview_path = self.cfg["core"]["config"].get("preview_path", "")
@@ -269,7 +281,9 @@ class DeployFactory:
         scheduler_output_dir = self.cfg["core"]["config"].get(
             "scheduler_output_dir", ""
         )
-        scheduler_system = self.cfg["core"]["config"].get("scheduler_system", "local")
+        scheduler_system = self.cfg["core"]["config"].get(
+            "scheduler_system", "local"
+        )
         if not preview_path:
             self.cfg["core"]["config"]["preview_path"] = str(
                 Path(base_dir_location) / "share" / "preview"
@@ -277,8 +291,12 @@ class DeployFactory:
         if not scheduler_output_dir:
             scheduler_output_dir = str(Path(base_dir_location) / "share")
         elif Path(scheduler_output_dir).parts[-1] != scheduler_system:
-            scheduler_output_dir = Path(scheduler_output_dir) / scheduler_system
-        self.cfg["core"]["config"]["scheduler_output_dir"] = str(scheduler_output_dir)
+            scheduler_output_dir = (
+                Path(scheduler_output_dir) / scheduler_system
+            )
+        self.cfg["core"]["config"]["scheduler_output_dir"] = str(
+            scheduler_output_dir
+        )
         self.cfg["core"]["config"]["keyfile"] = self.public_key_file
         git_exe = self.cfg["core"]["config"].get("git_path")
         self.cfg["core"]["config"]["git_path"] = git_exe or "git"
@@ -317,23 +335,41 @@ class DeployFactory:
             self.cfg["web"]["config"]["admin"] = admin[0]
         else:
             self.cfg["web"]["config"]["admin"] = admin
-        allowed_hosts = self.cfg["web"]["config"].get("allowed_hosts") or ["localhost"]
+        allowed_hosts = self.cfg["web"]["config"].get("allowed_hosts") or [
+            "localhost"
+        ]
         allowed_hosts.append(self.cfg["web"]["hosts"])
         allowed_hosts.append(f"{self.project_name}-httpd")
         self.cfg["web"]["config"]["allowed_hosts"] = list(set(allowed_hosts))
         self.cfg["web"]["config"].setdefault("allowed_hosts", ["localhost"])
 
         _webserver_items = {
-            "institution_logo": self.cfg["web"]["config"].get("institution_logo", ""),
-            "main_color": self.cfg["web"]["config"].get("main_color", "Tomato"),
-            "border_color": self.cfg["web"]["config"].get("border_color", "#6c2e1f"),
-            "hover_color": self.cfg["web"]["config"].get("hover_color", "#d0513a"),
-            "homepage_text": self.cfg["web"]["config"].get("homepage_text", ""),
+            "institution_logo": self.cfg["web"]["config"].get(
+                "institution_logo", ""
+            ),
+            "main_color": self.cfg["web"]["config"].get(
+                "main_color", "Tomato"
+            ),
+            "border_color": self.cfg["web"]["config"].get(
+                "border_color", "#6c2e1f"
+            ),
+            "hover_color": self.cfg["web"]["config"].get(
+                "hover_color", "#d0513a"
+            ),
+            "homepage_text": self.cfg["web"]["config"].get(
+                "homepage_text", ""
+            ),
             "imprint": self.cfg["web"]["config"].get("imprint", []),
-            "homepage_heading": self.cfg["web"]["config"].get("homepage_heading", ""),
-            "about_us_text": self.cfg["web"]["config"].get("about_us_text", ""),
+            "homepage_heading": self.cfg["web"]["config"].get(
+                "homepage_heading", ""
+            ),
+            "about_us_text": self.cfg["web"]["config"].get(
+                "about_us_text", ""
+            ),
             "contacts": self.cfg["web"]["config"].get("contacts", []),
-            "insitution_name": self.cfg["web"]["config"].get("insitution_name", ""),
+            "insitution_name": self.cfg["web"]["config"].get(
+                "insitution_name", ""
+            ),
             "menu_entries": self.cfg["web"]["config"].get("menu_entries", []),
         }
         try:
@@ -352,7 +388,9 @@ class DeployFactory:
         if self.local_debug:
             self.cfg["web"]["config"]["redis_host"] = self.cfg["web"]["hosts"]
         else:
-            self.cfg["web"]["config"]["redis_host"] = f"{self.project_name}-redis"
+            self.cfg["web"]["config"][
+                "redis_host"
+            ] = f"{self.project_name}-redis"
 
         server_name = self.cfg["web"]["config"].pop("server_name", [])
         if isinstance(server_name, str):
@@ -381,32 +419,41 @@ class DeployFactory:
             self.cfg["core"]["config"]["install_dir"], "bin"
         )
         for key in ("core", "web"):
-            self.cfg[key]["config"]["config_toml_file"] = str(self.web_conf_file)
+            self.cfg[key]["config"]["config_toml_file"] = str(
+                self.web_conf_file
+            )
         self._prep_vault()
         if ask_pass:
             email_user, self.email_password = get_email_credentials()
             self.cfg["vault"]["config"]["email_user"] = email_user
             self.cfg["vault"]["config"]["email_password"] = self.email_password
-        self.cfg["vault"]["config"]["ansible_python_interpreter"] = self.cfg["db"][
-            "config"
-        ].get("ansible_python_interpreter", "/usr/bin/python3")
+        self.cfg["vault"]["config"]["ansible_python_interpreter"] = self.cfg[
+            "db"
+        ]["config"].get("ansible_python_interpreter", "/usr/bin/python3")
         self.cfg["web"]["config"]["root_passwd"] = self.master_pass
         self.cfg["web"]["config"]["private_keyfile"] = self.private_key_file
         self.cfg["web"]["config"]["public_keyfile"] = self.public_key_file
-        self.cfg["web"]["config"]["apache_config_file"] = str(self.apache_config)
+        self.cfg["web"]["config"]["apache_config_file"] = str(
+            self.apache_config
+        )
         if ask_pass:
             self._prep_apache_config()
 
     def _prep_apache_config(self):
         with open(self.apache_config, "w") as f_obj:
-            f_obj.write((Path(asset_dir) / "web" / "freva_web.conf").read_text())
+            f_obj.write(
+                (Path(asset_dir) / "web" / "freva_web.conf").read_text()
+            )
 
     def _set_hostnames(self) -> None:
         """Set the hostnames from the config or if debug the alias."""
         default_ports = {"db": 3306, "freva_rest": 8080}
         if self.local_debug:
             for step in self.steps:
-                if isinstance(self.cfg[step], dict) and "hosts" in self.cfg[step]:
+                if (
+                    isinstance(self.cfg[step], dict)
+                    and "hosts" in self.cfg[step]
+                ):
                     self.cfg[step]["hosts"] = gethostbyname(gethostname())
                 if step in ("db", "freva_rest"):
                     self.cfg[step]["config"]["port"] = default_ports[step]
@@ -423,7 +470,9 @@ class DeployFactory:
             config["vault"] = deepcopy(config["db"])
             return config
         except FileNotFoundError:
-            raise ConfigurationError(f"No such file {self._inv_tmpl}") from None
+            raise ConfigurationError(
+                f"No such file {self._inv_tmpl}"
+            ) from None
         except KeyError:
             raise ConfigurationError("You must define a db section") from None
 
@@ -438,7 +487,11 @@ class DeployFactory:
                     sections.append(section)
         for section in sections:
             for key, value in self.cfg[section]["config"].items():
-                if not value and not self._empty_ok and not isinstance(value, bool):
+                if (
+                    not value
+                    and not self._empty_ok
+                    and not isinstance(value, bool)
+                ):
                     raise ConfigurationError(
                         f"{key} in {section} is empty in {self._inv_tmpl}"
                     ) from None
@@ -477,14 +530,18 @@ class DeployFactory:
         num_chars, num_digits = 30, 8
         num_chars -= num_digits
         characters = [
-            "".join([random.choice(string.ascii_letters) for i in range(num_chars)]),
+            "".join(
+                [random.choice(string.ascii_letters) for i in range(num_chars)]
+            ),
             "".join([random.choice(string.digits) for i in range(num_digits)]),
         ]
         str_characters = "".join(characters)
         _db_pass = "".join(random.sample(str_characters, len(str_characters)))
         while _db_pass.startswith("@"):
             # Vault treats values starting with "@" as file names.
-            _db_pass = "".join(random.sample(str_characters, len(str_characters)))
+            _db_pass = "".join(
+                random.sample(str_characters, len(str_characters))
+            )
         self._db_pass = _db_pass
         return self._db_pass
 
@@ -524,7 +581,9 @@ class DeployFactory:
 
     def parse_config(self, steps: list[str]) -> str | None:
         """Create config files for anisble and evaluation_system.conf."""
-        versions = json.loads((Path(__file__).parent / "versions.json").read_text())
+        versions = json.loads(
+            (Path(__file__).parent / "versions.json").read_text()
+        )
         additional_steps = set(steps) - set(self.steps)
         if additional_steps:
             pprint(
@@ -556,9 +615,9 @@ class DeployFactory:
                     new_key = f"{step.replace('-', '_')}_{key}"
                 config[step]["vars"][new_key] = value
             config[step]["vars"]["project_name"] = self.project_name
-            config[step]["vars"][f"{step.replace('-', '_')}_version"] = versions.get(
-                step, ""
-            )
+            config[step]["vars"][
+                f"{step.replace('-', '_')}_version"
+            ] = versions.get(step, "")
             config[step]["vars"]["debug"] = self.local_debug
             # Add additional keys
             self._set_additional_config_values(step, config)
@@ -651,7 +710,9 @@ class DeployFactory:
                 if line.startswith("solr.host"):
                     lines[num] = f"solr.host={self.cfg[step]['hosts']}\n"
                 if line.startswith("db.host"):
-                    lines[num] = f"db.host={self.cfg['db']['config']['host']}\n"
+                    lines[
+                        num
+                    ] = f"db.host={self.cfg['db']['config']['host']}\n"
         dump_file = self._get_files_copy("core")
         if dump_file:
             with dump_file.open("w") as f_obj:
@@ -660,13 +721,17 @@ class DeployFactory:
     def get_ansible_password(self, ask_pass: bool = False) -> dict[str, str]:
         """The passwords for the ansible environments."""
         ssh_pass_msg = "Give the [b]ssh[/b] password for remote login"
-        sudo_pass_msg = "Give the password elevating user privilege ([b]sudo[/b])"
+        sudo_pass_msg = (
+            "Give the password elevating user privilege ([b]sudo[/b])"
+        )
         if ask_pass:
             sudo_pass_msg += ", defaults to ssh password"
         passwords = {}
         sudo_key = "^BECOME password.*:\\s*?$"
         ssh_key = "^SSH password:\\s*?$"
-        passwords[sudo_key] = os.environ.get("ANSIBLE_BECOME_PASSWORD", "") or ""
+        passwords[sudo_key] = (
+            os.environ.get("ANSIBLE_BECOME_PASSWORD", "") or ""
+        )
         passwords[ssh_key] = os.environ.get("ANSIBLE_SSH_PASSWORD", "") or ""
         if ask_pass and not passwords[ssh_key]:
             passwords[ssh_key] = Prompt.ask(
@@ -697,9 +762,13 @@ class DeployFactory:
             Set the ssh port, in 99.9% of cases this should be left at port 22
         """
         try:
-            return self._play(ask_pass=ask_pass, verbosity=verbosity, ssh_port=ssh_port)
+            return self._play(
+                ask_pass=ask_pass, verbosity=verbosity, ssh_port=ssh_port
+            )
         except KeyboardInterrupt:
-            pprint(" [red][ERROR]: User interrupted execution[/]", file=sys.stderr)
+            pprint(
+                " [red][ERROR]: User interrupted execution[/]", file=sys.stderr
+            )
             raise KeyboardInterrupt() from None
 
     def get_steps_from_versions(
@@ -832,7 +901,9 @@ class DeployFactory:
             return None
         self.create_eval_config()
         logger.debug(inventory)
-        logger.info("Playing the playbooks for %s with ansible", ", ".join(self.steps))
+        logger.info(
+            "Playing the playbooks for %s with ansible", ", ".join(self.steps)
+        )
         logger.debug(self.playbooks)
         time.sleep(3)
         sig_handler = signal.getsignal(signal.SIGINT)
@@ -850,7 +921,9 @@ class DeployFactory:
         finally:
             signal.signal(signal.SIGINT, sig_handler)
         if result.status in ("timeout", "failed"):
-            raise DeploymentError(f"Deployment not successful: {result.status}")
+            raise DeploymentError(
+                f"Deployment not successful: {result.status}"
+            )
         elif result.status == "canceled":
             raise KeyboardInterrupt() from None
         return result

--- a/src/freva_deployment/keys.py
+++ b/src/freva_deployment/keys.py
@@ -88,7 +88,9 @@ class RandomKeys:
             str: The filename of the private key file.
         """
         self._check_crypto()
-        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(".key")
+        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(
+            ".key"
+        )
         if not temp_file.is_file():
             temp_file.write_bytes(self.private_key_pem)
         return str(temp_file)
@@ -101,7 +103,9 @@ class RandomKeys:
         Returns:
             str: The filename of the public key file.
         """
-        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(".pem")
+        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(
+            ".pem"
+        )
         if not temp_file.is_file():
             temp_file.write_bytes(self.public_key_pem)
         return str(temp_file)
@@ -114,7 +118,9 @@ class RandomKeys:
         Returns:
             str: The filename of the certificate chain file.
         """
-        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(".crt")
+        temp_file = (Path(self._temp_dir.name) / self.base_name).with_suffix(
+            ".crt"
+        )
         if not temp_file.is_file():
             temp_file.write_bytes(self.certificate_chain)
         return str(temp_file)
@@ -131,7 +137,9 @@ class RandomKeys:
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, self.common_name)])
+                x509.Name(
+                    [x509.NameAttribute(NameOID.COMMON_NAME, self.common_name)]
+                )
             )
             .sign(self.private_key, hashes.SHA256(), default_backend())
         )
@@ -144,7 +152,8 @@ class RandomKeys:
             .serial_number(x509.random_serial_number())
             .not_valid_before(datetime.datetime.now(datetime.UTC))
             .not_valid_after(
-                datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=365)
+                datetime.datetime.now(datetime.UTC)
+                + datetime.timedelta(days=365)
             )
             .sign(self.private_key, hashes.SHA256(), default_backend())
         )

--- a/src/freva_deployment/ui/deployment_tui/base.py
+++ b/src/freva_deployment/ui/deployment_tui/base.py
@@ -82,7 +82,9 @@ def selectFile(starting_value: str = "", *args, **keywords):
     F.set_colors()
     F.wCommand.show_bold = True
     if starting_value:
-        if not os.path.exists(os.path.abspath(os.path.expanduser(starting_value))):
+        if not os.path.exists(
+            os.path.abspath(os.path.expanduser(starting_value))
+        ):
             F.value = os.getcwd()
         else:
             F.value = starting_value
@@ -225,7 +227,9 @@ class BaseForm(npyscreen.FormMultiPageWithMenus, npyscreen.FormWithMenus):
 
     def clear_cache(self):
         """Clear the app cache."""
-        with open(self.parentApp.cache_dir / "freva_deployment.json", "w") as f:
+        with open(
+            self.parentApp.cache_dir / "freva_deployment.json", "w"
+        ) as f:
             json.dump({}, f, indent=3)
         self.parentApp.reset()
 
@@ -239,9 +243,9 @@ class BaseForm(npyscreen.FormMultiPageWithMenus, npyscreen.FormWithMenus):
 
     def create(self) -> None:
         """Setup the form."""
-        self.how_exited_handers[npyscreen.wgwidget.EXITED_ESCAPE] = (
-            self.parentApp.exit_application
-        )
+        self.how_exited_handers[
+            npyscreen.wgwidget.EXITED_ESCAPE
+        ] = self.parentApp.exit_application
         self.add_handlers({"^O": self.parentApp.load_dialog})
         self.add_handlers({"^S": self.parentApp.save_dialog})
         self.add_handlers({"^K": self.previews_form})

--- a/src/freva_deployment/ui/deployment_tui/deploy_forms.py
+++ b/src/freva_deployment/ui/deployment_tui/deploy_forms.py
@@ -117,7 +117,9 @@ class CoreScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleCombo,
                     name=f"{self.num}Workload manger",
-                    value=self.scheduler_index(cast(str, cfg.get("scheduler_system"))),
+                    value=self.scheduler_index(
+                        cast(str, cfg.get("scheduler_system"))
+                    ),
                     values=self.scheduler_systems,
                 ),
                 True,
@@ -188,7 +190,9 @@ class CoreScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleFilename,
                     name=f"{self.num}Python path on remote machine:",
-                    value=cfg.get("ansible_python_interpreter", "/usr/bin/python3"),
+                    value=cfg.get(
+                        "ansible_python_interpreter", "/usr/bin/python3"
+                    ),
                 ),
                 False,
             ),
@@ -378,7 +382,9 @@ class WebScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleText,
                     name=f"{self.num}A brief describtion of the project:",
-                    value=cfg.get("homepage_heading", "Lorem ipsum dolor sit amet"),
+                    value=cfg.get(
+                        "homepage_heading", "Lorem ipsum dolor sit amet"
+                    ),
                 ),
                 True,
             ),
@@ -543,7 +549,9 @@ class WebScreen(BaseForm):
             ldap_model=(
                 self.add_widget_intelligent(
                     npyscreen.TitleCombo,
-                    name=(f"{self.num}Ldap tools class to be used for authentication."),
+                    name=(
+                        f"{self.num}Ldap tools class to be used for authentication."
+                    ),
                     value=current_ldab_model,
                     values=availalbe_ldab_models,
                 ),
@@ -575,7 +583,9 @@ class WebScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleFilename,
                     name=f"{self.num}Pythonpath on remote machine:",
-                    value=cfg.get("ansible_python_interpreter", "/usr/bin/python3"),
+                    value=cfg.get(
+                        "ansible_python_interpreter", "/usr/bin/python3"
+                    ),
                 ),
                 False,
             ),
@@ -653,7 +663,9 @@ class DBScreen(BaseForm):
             data_path=(
                 self.add_widget_intelligent(
                     npyscreen.TitleText,
-                    name=(f"{self.num}Parent directory for any permanent data:"),
+                    name=(
+                        f"{self.num}Parent directory for any permanent data:"
+                    ),
                     value=cast(str, cfg.get("data_path", "/opt/freva")),
                 ),
                 True,
@@ -684,7 +696,9 @@ class DBScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleFilename,
                     name=f"{self.num}Pythonpath on remote machine:",
-                    value=cfg.get("ansible_python_interpreter", "/usr/bin/python3"),
+                    value=cfg.get(
+                        "ansible_python_interpreter", "/usr/bin/python3"
+                    ),
                 ),
                 False,
             ),
@@ -790,7 +804,9 @@ class FrevaRestScreen(BaseForm):
                 self.add_widget_intelligent(
                     npyscreen.TitleFilename,
                     name=f"{self.num}Pythonpath on remote machine:",
-                    value=cfg.get("ansible_python_interpreter", "/usr/bin/python3"),
+                    value=cfg.get(
+                        "ansible_python_interpreter", "/usr/bin/python3"
+                    ),
                 ),
                 False,
             ),
@@ -821,7 +837,9 @@ class RunForm(npyscreen.FormMultiPageAction):
 
         self.parentApp.thread_stop.set()
         if not self.project_name.value:
-            npyscreen.notify_confirm("You have to set a project name", title="ERROR")
+            npyscreen.notify_confirm(
+                "You have to set a project name", title="ERROR"
+            )
             return
         missing_form: None | str = self.parentApp.check_missing_config()
         if missing_form:
@@ -840,7 +858,9 @@ class RunForm(npyscreen.FormMultiPageAction):
         else:
             gen_keys = bool(self.gen_keys.value)
         for key_type, keyfile in cert_files.items():
-            key_file = Path(get_current_file_dir(save_file.parent, str(keyfile)))
+            key_file = Path(
+                get_current_file_dir(save_file.parent, str(keyfile))
+            )
             for step, deploy_form in self.parentApp._forms.items():
                 if not keyfile or not Path(key_file).is_file():
                     if (
@@ -849,11 +869,11 @@ class RunForm(npyscreen.FormMultiPageAction):
                         and gen_keys is False
                     ):
                         if keyfile:
-                            msg = (
-                                f"{key_type} certificate file `{key_file}` must exist."
-                            )
+                            msg = f"{key_type} certificate file `{key_file}` must exist."
                         else:
-                            msg = f"You must give a {key_type} certificate file."
+                            msg = (
+                                f"You must give a {key_type} certificate file."
+                            )
                         npyscreen.notify_confirm(msg, title="ERROR")
                         return
         _ = self.parentApp.save_config_to_file(
@@ -888,9 +908,9 @@ class RunForm(npyscreen.FormMultiPageAction):
 
     def create(self) -> None:
         """Custom definitions executed when the from gets created."""
-        self.how_exited_handers[npyscreen.wgwidget.EXITED_ESCAPE] = (
-            self.parentApp.exit_application
-        )
+        self.how_exited_handers[
+            npyscreen.wgwidget.EXITED_ESCAPE
+        ] = self.parentApp.exit_application
         self._add_widgets()
 
     def _add_widgets(self) -> None:

--- a/src/freva_deployment/ui/deployment_tui/main_window.py
+++ b/src/freva_deployment/ui/deployment_tui/main_window.py
@@ -84,12 +84,18 @@ class MainApp(npyscreen.NPSAppManaged):
             CoreScreen,
             name="Core deployment",
         )
-        self._forms["web"] = self.addForm("SECOND", WebScreen, name="Web deployment")
-        self._forms["db"] = self.addForm("THIRD", DBScreen, name="Database deployment")
+        self._forms["web"] = self.addForm(
+            "SECOND", WebScreen, name="Web deployment"
+        )
+        self._forms["db"] = self.addForm(
+            "THIRD", DBScreen, name="Database deployment"
+        )
         self._forms["freva_rest"] = self.addForm(
             "FOURTH", FrevaRestScreen, name="Freva Rest deployment"
         )
-        self._setup_form = self.addForm("SETUP", RunForm, name="Apply the Deployment")
+        self._setup_form = self.addForm(
+            "SETUP", RunForm, name="Apply the Deployment"
+        )
 
     def exit_application(self, *args, **kwargs) -> None:
         value = npyscreen.notify_ok_cancel(
@@ -151,7 +157,9 @@ class MainApp(npyscreen.NPSAppManaged):
             the_selected_file = str(the_selected_file.expanduser().absolute())
             self.check_missing_config(stop_at_missing=False)
             self._setup_form.inventory_file.value = the_selected_file
-            self.save_config_to_file(save_file=the_selected_file, write_toml_file=True)
+            self.save_config_to_file(
+                save_file=the_selected_file, write_toml_file=True
+            )
 
     def _update_config(self, config_file: Path | str) -> None:
         """Update the main window after a new configuration has been loaded."""

--- a/src/freva_deployment/utils.py
+++ b/src/freva_deployment/utils.py
@@ -54,8 +54,12 @@ class AssetDir:
     this_module = "freva_deployment"
 
     def __init__(self):
-        self._user_asset_dir = Path(appdirs.user_data_dir()) / "freva" / "deployment"
-        self._user_config_dir = Path(appdirs.user_config_dir()) / "freva" / "deployment"
+        self._user_asset_dir = (
+            Path(appdirs.user_data_dir()) / "freva" / "deployment"
+        )
+        self._user_config_dir = (
+            Path(appdirs.user_config_dir()) / "freva" / "deployment"
+        )
 
     @staticmethod
     def get_dirs(user: bool = True, key: str = "data") -> Path:
@@ -100,7 +104,9 @@ class AssetDir:
             inventory_file.unlink()
         except FileNotFoundError:
             pass
-        shutil.copy2(self.asset_dir / "config" / "inventory.toml", inventory_file)
+        shutil.copy2(
+            self.asset_dir / "config" / "inventory.toml", inventory_file
+        )
         return self._user_config_dir
 
     @property
@@ -174,9 +180,9 @@ def _create_new_config(inp_file: Path) -> Path:
                     ]["config"].pop(key)
         else:
             config["freva_rest"] = config.pop("databrowser")
-            config["freva_rest"]["config"]["freva_rest_port"] = config["freva_rest"][
-                "config"
-            ].pop("databrowser_port", "")
+            config["freva_rest"]["config"]["freva_rest_port"] = config[
+                "freva_rest"
+            ]["config"].pop("databrowser_port", "")
             config["freva_rest"]["config"]["freva_rest_playbook"] = config[
                 "freva_rest"
             ]["config"].pop("databrowser_playbook", "")
@@ -204,7 +210,9 @@ def load_config(inp_file: str | Path, convert: bool = False) -> dict[str, Any]:
     return config
 
 
-def get_setup_for_service(service: str, setups: list[ServiceInfo]) -> tuple[str, str]:
+def get_setup_for_service(
+    service: str, setups: list[ServiceInfo]
+) -> tuple[str, str]:
     """Get the setup of a service configuration."""
     for setup in setups:
         if setup.name == service:
@@ -217,7 +225,9 @@ def read_db_credentials(
 ) -> dict[str, str]:
     """Read database config."""
     with cert_file.open() as f_obj:
-        key = "".join([k.strip() for k in f_obj.readlines() if not k.startswith("-")])
+        key = "".join(
+            [k.strip() for k in f_obj.readlines() if not k.startswith("-")]
+        )
         sha = hashlib.sha512(key.encode()).hexdigest()
     url = f"http://{db_host}:{port}/vault/data/{sha}"
     return requests.get(url).json()
@@ -242,11 +252,15 @@ def get_email_credentials() -> tuple[str, str]:
         if not username:
             username = Prompt.ask("[green b]Username[/] for mail server")
         if not password:
-            password = Prompt.ask("[green b]Password[/] for mail server", password=True)
+            password = Prompt.ask(
+                "[green b]Password[/] for mail server", password=True
+            )
     return username, password
 
 
-def get_passwd(master_pass: Optional[str] = None, min_characters: int = 8) -> str:
+def get_passwd(
+    master_pass: Optional[str] = None, min_characters: int = 8
+) -> str:
     """Create a secure pasword.
 
     Parameters
@@ -301,7 +315,9 @@ def _create_passwd(min_characters: int, msg: str = "") -> str:
     """Create passwords."""
     master_pass = Prompt.ask(msg or password_prompt, password=True)
     _passwd_is_good(master_pass, min_characters)
-    master_pass_2 = Prompt.ask("[bold green]re-enter[/] master password", password=True)
+    master_pass_2 = Prompt.ask(
+        "[bold green]re-enter[/] master password", password=True
+    )
     if master_pass != master_pass_2:
         raise ValueError("Passwords do not match")
     return master_pass

--- a/src/freva_deployment/versions.py
+++ b/src/freva_deployment/versions.py
@@ -26,7 +26,9 @@ class VersionAction(argparse._VersionAction):
 
 def display_versions() -> str:
     """Get all service versions for display."""
-    minimum_version = json.loads((Path(__file__).parent / "versions.json").read_text())
+    minimum_version = json.loads(
+        (Path(__file__).parent / "versions.json").read_text()
+    )
     lookup = {
         "freva_rest": "freva-rest API",
         "core": "freva-core",
@@ -52,7 +54,9 @@ def get_steps_from_versions(detected_versions: Dict[str, str]) -> List[str]:
     -------
     list: A list of services that should be updated.
     """
-    minimum_version = json.loads((Path(__file__).parent / "versions.json").read_text())
+    minimum_version = json.loads(
+        (Path(__file__).parent / "versions.json").read_text()
+    )
     steps = []
     lookup = {"solr": "freva_rest", "vault": "db"}
     for service, min_version in minimum_version.items():


### PR DESCRIPTION
minor bugfix for `freva-migrate` when the database does not have `information_schema.COLUMN_STATISTICS`

e.g. I could not find that table in the db at xces-prod, the freshly created one at xces9 deployment nor at www-regiklim.

I do not know how prevalent that problem could be.