### PR TITLE
Do not cache prep calls.

### DIFF
--- a/assets/share/freva/deployment/playbooks/db-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/db-server-playbook.yml
@@ -20,6 +20,7 @@
     data_path: '{{db_data_path|regex_replace("^~", ansible_env.HOME)}}/{{ project_name }}/db_service'
     continer_name: "{{ db_name }}"
     vault_name: "{{project_name}}-vault"
+    vault_token_path: "{{db_data_path|regex_replace('^~', ansible_env.HOME)}}/{{ project_name }}/vault_service/files/keys"
     adminer_name: "{{project_name}}-adminer"
   tasks:
     - name: Get UID
@@ -45,7 +46,7 @@
       stat:
         path: /etc/cron.daily
       register: cron
-    - name: Registering vault volume path
+    - name: Registering vault service path
       stat:
         path: /etc/systemd/system/{{vault_name}}.service
       register: vault_service
@@ -95,6 +96,20 @@
       stat:
         path: '{{db_data_path|regex_replace("^~", ansible_env.HOME)}}/{{ project_name }}/db_service'
       register: db_service
+    - name: Register path to vault keys
+      stat:
+        path: "{{vault_token_path}}"
+      register: token_path
+    - name: Check vault keys
+      block:
+        - name: Base64 decode vault key path
+          command: base64 -d "{{vault_token_path}}"
+      rescue:
+        - name: Delete vault dir because its content is not valid
+          file:
+            state: absent
+            path: "{{db_data_path|regex_replace('^~', ansible_env.HOME)}}/{{ project_name }}/vault_service"
+      when: token_path.stat.exists
     - name:  Set db_service path exist facts
       set_fact:
         db_service_exist: "{{ db_service.stat.exists }}"

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -7,6 +7,11 @@ What's new
    :maxdepth: 0
    :titlesonly:
 
+v2408.0.1
+~~~~~~~~
+* Some bug-fixes.
+
+
 v2408.0.0
 ~~~~~~~~
 * Add zarr-streaming deployment.

--- a/src/freva_deployment/__init__.py
+++ b/src/freva_deployment/__init__.py
@@ -1,7 +1,7 @@
 import argparse
 from urllib.request import urlretrieve
 
-__version__ = "2408.0.0"
+__version__ = "2408.0.1"
 
 FREVA_PYTHON_VERSION = "3.12"
 AVAILABLE_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -31,14 +31,8 @@ from .error import ConfigurationError, handled_exception
 from .keys import RandomKeys
 from .logger import logger
 from .runner import RunnerDir
-from .utils import (
-    RichConsole,
-    asset_dir,
-    config_dir,
-    get_cache_information,
-    get_passwd,
-    load_config,
-)
+from .utils import (RichConsole, asset_dir, config_dir, get_cache_information,
+                    get_passwd, load_config)
 from .versions import get_steps_from_versions
 
 
@@ -1063,7 +1057,7 @@ class DeployFactory:
             cowpath=os.getenv("ANSIBLE_COW_PATH", shutil.which("cowsay") or ""),
             cow_selection="random",
             interpreter_python="auto_silent",
-            timeout="5",
+            timeout="15",
         )
         logger.debug("CONFIG\n%s", self._td.ansible_config_file.read_text())
         extravars: dict[str, str] = {

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -31,8 +31,14 @@ from .error import ConfigurationError, handled_exception
 from .keys import RandomKeys
 from .logger import logger
 from .runner import RunnerDir
-from .utils import (RichConsole, asset_dir, config_dir, get_cache_information,
-                    get_passwd, load_config)
+from .utils import (
+    RichConsole,
+    asset_dir,
+    config_dir,
+    get_cache_information,
+    get_passwd,
+    load_config,
+)
 from .versions import get_steps_from_versions
 
 

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -10,9 +10,8 @@ import shutil
 import string
 import sys
 import time
-from base64 import b64decode, b64encode
+from base64 import b64encode
 from copy import deepcopy
-from functools import lru_cache
 from getpass import getuser
 from pathlib import Path
 from socket import gethostbyname, gethostname
@@ -38,7 +37,6 @@ from .utils import (
     config_dir,
     get_cache_information,
     get_passwd,
-    is_bundeled,
     load_config,
 )
 from .versions import get_steps_from_versions
@@ -206,7 +204,6 @@ class DeployFactory:
             "You must give a valid path to a private key file."
         ) from None
 
-    @lru_cache()
     def _prep_vault(self) -> None:
         """Prepare the vault."""
         self.cfg["vault"]["config"].setdefault("ansible_become_user", "root")
@@ -227,7 +224,6 @@ class DeployFactory:
             "host", self.cfg["db"]["hosts"]
         )
 
-    @lru_cache()
     def _prep_db(self) -> None:
         """prepare the mariadb service."""
         self._config_keys.append("db")
@@ -256,7 +252,6 @@ class DeployFactory:
         self._prep_vault()
         self._prep_web(False)
 
-    @lru_cache()
     def _prep_data_loader(self, password: Optional[str] = None) -> None:
         """Prepare the data-loader."""
         self._prep_freva_rest()
@@ -373,7 +368,6 @@ class DeployFactory:
             },
         }
 
-    @lru_cache()
     def _prep_freva_rest(self, prep_web=True) -> None:
         """prepare the freva_rest service."""
         self._config_keys.append("freva_rest")
@@ -410,7 +404,6 @@ class DeployFactory:
         if prep_web:
             self._prep_web(False)
 
-    @lru_cache()
     def _prep_core(self) -> None:
         """prepare the core deployment."""
         self._config_keys.append("core")
@@ -575,12 +568,10 @@ class DeployFactory:
         if ask_pass:
             self._prep_apache_config()
 
-    @lru_cache()
     def _prep_apache_config(self):
         with open(self.apache_config, "w") as f_obj:
             f_obj.write((Path(asset_dir) / "web" / "freva_web.conf").read_text())
 
-    @lru_cache()
     def _prep_local_debug(self) -> None:
         """Prepare the system for a potential local debug."""
         default_ports = {"db": 3306, "freva_rest": 7777}


### PR DESCRIPTION
This fixes the bug that the master password that was temporarily set when checking for valid configs are cached. The master password was temporarily set when performing checks to avoid typing the master password twice. 