### PR TITLE
Mongo password reset routine + a bit of leftover changes related to mongo and CI

### DIFF
--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -285,18 +285,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: linux/amd64
-            target: linux-x64
           - arch: linux/arm64
             target: linux-arm64
           - arch: linux/arm/v7
-            target: linux-armv7
-          - arch: linux/386
-            target: linux-i386
+            target: linux-armvl7
+          - arch: linux/arm/v6
+            target: linux-armvl6
           - arch: linux/ppc64le
-            target: linux-ppc64le
+            target: linux-ppc64
           - arch: linux/s390x
             target: linux-s390x
+          - arch: linux/i386
+            target: linux-i386
 
     steps:
 

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -287,12 +287,10 @@ jobs:
         include:
           - arch: linux/amd64
             target: linux-x64
-          - arch: linux/arm64/v8
+          - arch: linux/arm64
             target: linux-arm64
           - arch: linux/arm/v7
             target: linux-armv7
-          - arch: linux/arm/v5
-            target: linux-armv5
           - arch: linux/386
             target: linux-i386
           - arch: linux/ppc64le

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -287,18 +287,18 @@ jobs:
         include:
           - arch: linux/amd64
             target: linux-x64
-          - arch: linux/arm64
+          - arch: linux/arm64/v8
             target: linux-arm64
           - arch: linux/arm/v7
-            target: linux-armvl7
-          - arch: linux/arm/v6
-            target: linux-armvl6
+            target: linux-armv7
+          - arch: linux/arm/v5
+            target: linux-armv5
+          - arch: linux/386
+            target: linux-i386
           - arch: linux/ppc64le
-            target: linux-ppc64
+            target: linux-ppc64le
           - arch: linux/s390x
             target: linux-s390x
-          - arch: linux/i386
-            target: linux-i386
 
     steps:
 

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -129,7 +129,7 @@ jobs:
         shell: pwsh
       - name: Load Release URL File from release job
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: release_url
       - name: Get version
@@ -250,7 +250,7 @@ jobs:
 
       - name: Load Release URL File from release job
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: release_url
       - name: Get Release File Name & Upload URL
@@ -365,7 +365,7 @@ jobs:
           -C ./dist deploy-freva
       - name: Load Release URL File from release job
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: release_url
       - name: Get Release File Name & Upload URL

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -285,6 +285,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - arch: linux/amd64
+            target: linux-x64
           - arch: linux/arm64
             target: linux-arm64
           - arch: linux/arm/v7

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v4
         env:
           GITHUB_TOKEN: ${{ secrets.ASSET_TOKEN }}
         with:

--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: actions/create-release@v4
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ASSET_TOKEN }}
         with:
@@ -35,7 +35,7 @@ jobs:
         run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
       - name: Save Release URL File for publish
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: release_url
           path: release_url.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG VERSION
 LABEL org.opencontainers.image.authors="DRKZ-CLINT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bullseye-20240904
 
 ARG VERSION
 LABEL org.opencontainers.image.authors="DRKZ-CLINT"

--- a/assets/share/freva/deployment/playbooks/freva_rest-server-compose-template.yml
+++ b/assets/share/freva/deployment/playbooks/freva_rest-server-compose-template.yml
@@ -46,8 +46,6 @@ services:
       - {{freva_rest_name}}
 {% endif %}
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=mongo
-      - MONGO_INITDB_ROOT_PASSWORD={{root_passwd}}
       - MONGO_INITDB_DATABASE=search_stats
     volumes:
 {% for volume in mongo_volumes %}

--- a/assets/share/freva/deployment/playbooks/freva_rest-server-compose-template.yml
+++ b/assets/share/freva/deployment/playbooks/freva_rest-server-compose-template.yml
@@ -29,16 +29,15 @@ services:
       - 8983:8983
 
   {{mongo_name}}:
+    image: docker.io/mongo:latest
+    container_name: {{ mongo_name }}
+    hostname: {{ mongo_name }}
 {% if (become == true and ansible_become_user == 'root') or ansible_user == 'root' %}
-    container_name: {{mongo_name}}
+    entrypoint: /tmp/mongo-flush-pass-entrypoint.sh
 {% else %}
-    container_name: {{mongo_name}}
     user: root:0
     entrypoint: /tmp/entrypoint.sh
 {% endif %}
-    image: docker.io/mongo:latest
-    container_name: {{mongo_name}}
-    hostname: {{mongo_name}}
 {% if debug %}
     network_mode: host
 {% else %}

--- a/assets/share/freva/deployment/playbooks/freva_rest-server-playbook.yml
+++ b/assets/share/freva/deployment/playbooks/freva_rest-server-playbook.yml
@@ -9,6 +9,7 @@
     freva_rest_name: "{{project_name}}-freva_rest"
     databrowser_name: "{{project_name}}-databrowser"
     compose_file: '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/compose_services/{{freva_rest_name}}-compose.yml'
+    flush_mongo_pass_path: '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/{{ project_name }}/freva_rest/mongo-flush-pass-entrypoint.sh'
     solr_name: "{{project_name}}-solr"
     mongo_name: "{{project_name}}-mongo"
     data_path: '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/{{project_name}}/freva_rest'
@@ -30,6 +31,8 @@
     mongo_volumes:
       - '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/{{project_name}}/freva_rest/stats:/data/db:z'
       - '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/{{ project_name }}/freva_rest/rootless-entrypoint.sh:/tmp/entrypoint.sh:z'
+      - '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/{{ project_name }}/freva_rest/mongo-flush-pass-entrypoint.sh:/tmp/mongo-flush-pass-entrypoint.sh:z'
+      - '{{freva_rest_data_path|regex_replace("^~", ansible_env.HOME)}}/freva-service-config/mongo/mongo-userdata-init.js:/docker-entrypoint-initdb.d/mongo-userdata-init.js:ro'
     ansible_become_user: "{{ freva_rest_ansible_become_user | default('root') }}"
   tasks:
     - name: Decode Base64 information content
@@ -177,6 +180,13 @@
       template:
         src: "{{ asset_dir }}/playbooks/freva_rest-server-compose-template.yml"
         dest: "{{compose_file}}"
+    - name: Deploy and set permissions for MongoDB flush password entrypoint
+      template:
+        src: "{{ asset_dir }}/script/mongo-flush-pass-entrypoint.sh"
+        dest: "{{flush_mongo_pass_path}}"
+        owner: "{{ uid }}"
+        group: "{{ gid }}"
+        mode: "0755"
     - name: Creating systemd services
       shell: |
         /tmp/create_systemd.py {{freva_rest_name}} compose --enable --project-name {{freva_rest_name}} -f {{compose_file}} up --remove-orphans

--- a/assets/share/freva/deployment/scripts/mongo-flush-pass-entrypoint.sh
+++ b/assets/share/freva/deployment/scripts/mongo-flush-pass-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+MONGODB_USER=${MONGODB_USER:-"mongo"}
+MONGODB_PASSWORD=${MONGODB_PASSWORD:-"{{root_passwd}}"}
+LOG_FILE="/var/log/mongodb.log"
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+wait_for_mongo() {
+    # TODO: For a small test environemt, 30 seconds was too long, but to be safe and sure in a real env, we should keep it at 30 seconds
+    for i in {1..30}; do
+        if mongosh --quiet --eval "db.adminCommand('ping')" &>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+reset_user() {
+    log "Starting mongo without auth for user reset..."
+    mongod --bind_ip_all --fork --logpath "$LOG_FILE" --noauth
+    
+    sleep 5
+    
+    log "striping existing users and creating admin user again..."
+    mongosh admin --quiet --eval "
+        db.dropUser('${MONGODB_USER}');
+        db.createUser({
+            user: '${MONGODB_USER}',
+            pwd: '${MONGODB_PASSWORD}',
+            roles: [
+                { role: 'root', db: 'admin' },
+                { role: 'userAdminAnyDatabase', db: 'admin' },
+                { role: 'dbAdminAnyDatabase', db: 'admin' },
+                { role: 'readWriteAnyDatabase', db: 'admin' }
+            ]
+        });"
+    
+    if [ $? -eq 0 ]; then
+        log "User reset successfully"
+        mongod --shutdown
+        sleep 5
+        return 0
+    else
+        log "Failed to reset user"
+        mongod --shutdown
+        sleep 5
+        return 1
+    fi
+}
+
+verify_auth() {
+    log "Verifying authentication..."
+    mongosh admin --quiet --eval "
+        try {
+            db.auth('${MONGODB_USER}', '${MONGODB_PASSWORD}');
+            db.adminCommand('listDatabases');
+            quit(0);
+        } catch(err) {
+            quit(1);
+        }"
+}
+
+main() {
+    log "Starting mongo without auth to verify and then reset credentials..."
+    mongod --bind_ip_all --fork --logpath "$LOG_FILE" --noauth
+    
+    sleep 5
+    
+    if ! verify_auth; then
+        log "Authentication failed with existing credentials - resetting user..."
+        mongod --shutdown
+        sleep 5
+        reset_user
+    else
+        log "Existing credentials are valid"
+        mongod --shutdown
+        sleep 5
+    fi
+    
+    log "Starting MongoDB with authentication..."
+    exec mongod --bind_ip_all --auth
+}
+
+main "$@"


### PR DESCRIPTION
In this PR we are going to introduce a new routine in the `_setup_mongo` to restart the newly defined password when we are deploying the Freva instance with the new password for the MongoDB

Because CI was red, and as the version of upload and download artifact were deprecated i upgraded to the version 3