### PR TITLE
fix: ensure ansible_python_interpreter is set in all playbook runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ src/freva_deployment/ui/__pycache__
 *.egg*
 *.key
 *.crt
+.DS_Store

--- a/src/freva_deployment/deploy.py
+++ b/src/freva_deployment/deploy.py
@@ -1061,7 +1061,13 @@ class DeployFactory:
             if str(error):
                 pprint(f" [red][ERROR]: {error}[/]", file=sys.stderr)
             raise KeyboardInterrupt() from None
-
+    def _set_python_interpreter(
+        self, step: str, config: dict[str, ConfigType]
+    ) -> None:
+        python_exe = self.cfg[step].get("ansible_python_interpreter", "").strip()
+        interp = python_exe or "/usr/bin/python"
+        config[step]["vars"][f"{step}_ansible_python_interpreter"] = interp
+        config[step]["vars"]["ansible_python_interpreter"] = interp
     def get_steps_from_versions(
         self,
         envvars: dict[str, str],
@@ -1115,10 +1121,7 @@ class DeployFactory:
                     "version_file_path": str(version_path),
                     f"{step.replace('-', '_')}_version": versions[step],
                 }
-                python_exe = self.cfg[step].get("ansible_python_interpreter", "")
-                config[step]["vars"][f"{step}_ansible_python_interpreter"] = (
-                    python_exe or "/usr/bin/python"
-                )
+                self._set_python_interpreter(step, config)
         config.setdefault("core", {})
         config["core"].setdefault("vars", {})
         config["core"]["vars"]["core_install_dir"] = cfg["core"]["install_dir"]


### PR DESCRIPTION
This PR fixes `ansible_python_interpreter` not being passed to the version check playbook, causing Ansible to fall back to auto-discovery and pick up the default system Python on managed nodes. On hosts like levante4.dkrz.de the system Python is older than 3.8, which is incompatible with ansible-core ≥ 2.17 module syntax and breaks the deployment.

A helper is introduced so that both the main deployment and version check code paths always set the interpreter consistently.

An alternative would be to exclude `core` from [this list](https://github.com/freva-org/freva-admin/blob/main/src/freva_deployment/deploy.py#L1075), but that only masks the symptom; any new service added in the future would face the same issue again.